### PR TITLE
Remove non-exsistant packages

### DIFF
--- a/Gnome/packages.x86_64
+++ b/Gnome/packages.x86_64
@@ -312,8 +312,6 @@ system-config-printer
 # Gnome
 accountsservice
 adwaita-icon-theme
-adwaita-qt5
-adwaita-qt6
 baobab
 dconf-editor
 eog


### PR DESCRIPTION
adwaita-qt5 and adwaita-qt6 got nuked from arch repos