### PR TITLE
Added power submenu to grub menu, correct permissions to added 39_pow…

### DIFF
--- a/Gnome/etc/grub.d/39_power_menu
+++ b/Gnome/etc/grub.d/39_power_menu
@@ -1,0 +1,15 @@
+#!/bin/sh
+exec tail -n +3 $0
+# 
+# Power submenu
+# 
+submenu "Power" --class power {
+    menuentry "Shutdown" --class shutdown {
+        halt
+    }
+
+    menuentry "Reboot" --class reboot {
+        reboot
+    }
+}
+

--- a/Gnome/profiledef.sh
+++ b/Gnome/profiledef.sh
@@ -20,6 +20,7 @@ file_permissions=(
   ["/etc/shadow"]="0:0:0400"
   ["/etc/gshadow"]="0:0:0400"
   ["/etc/sudoers"]="0:0:0440"
+  ["/etc/grub.d/39_power_menu"]="0:0:755"
   ["/root"]="0:0:750"
   ["/root/.automated_script.sh"]="0:0:755"
   ["/usr/local/bin/choose-mirror"]="0:0:755"


### PR DESCRIPTION
Added a Power submenu (Shutdown, Reboot) to the GRUB menu, allowing users to perform these actions from GRUB.

# Changes
- Added "/etc/grub.d/39_power_menu"
- Configured file permissions in `profiledef.sh` so that `39_power_menu` is executable in the generated ISO and `grub-mkconfig` can execute it.

# Testing
Tested in VM and on my secondary machine (Acer aspire R11)