### PR TITLE
pass arguments to function

### DIFF
--- a/Gnome/etc/skel/.config/fish/config.fish
+++ b/Gnome/etc/skel/.config/fish/config.fish
@@ -60,7 +60,7 @@ end
 
 # Fish command history
 function history
-    builtin history --show-time='%F %T '
+    builtin history --show-time='%F %T ' $argv
 end
 
 function backup --argument filename


### PR DESCRIPTION
Currently there is no way to pass additional arguments to this custom function, so for example `history -R` won't do anything. Make it accept arguments to correc this behaviour.